### PR TITLE
fix: x3d defs caching

### DIFF
--- a/packages/io/x3d-deserializer/src/parse.js
+++ b/packages/io/x3d-deserializer/src/parse.js
@@ -50,7 +50,6 @@ let x3dDefinition = x3dTypes.X3D // what kind of object beinging created
 
 // high level elements / definitions
 const x3dObjects = [] // list of objects
-const x3dDefs = new Map() // list of named objects
 
 const x3dMaterials = [] // list of materials
 const x3dTextures = [] // list of textures
@@ -110,6 +109,7 @@ const getObjectId = () => ('0000' + objectId++).slice(-4)
 const createX3DParser = (src, pxPmm) => {
   // create a parser for the XML
   const parser = new saxes.SaxesParser()
+  const x3dDefs = new Map() // list of named objects
 
   parser.on('error', (e) => {
     console.log(`error: line ${e.line}, column ${e.column}, bad character [${e.c}]`)


### PR DESCRIPTION
If we use this parser for multiple files with identical DEF signatures this caching will remove necessary definitions for the x3d.

Now it will be empty for every new parser.

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Does your submission pass tests?


> Note: please do NOT include build files (those generate by the build-xxx commands) with your PR,

Thank you for your help in advance, much appreciated !
